### PR TITLE
Adding addSampleFromDataArray method to NPM module.

### DIFF
--- a/js/npm/index.js
+++ b/js/npm/index.js
@@ -309,6 +309,17 @@ class Engine {
       }
   }
 
+    addSampleFromDataArray(name, sample, numberOfChannels, length, sampleRate) {
+      this.node.port.postMessage({
+        type: "loadsample",
+        sample: sample,
+        channels: numberOfChannels,
+        length: length,
+        name: this.encoder.encode("\\"+ name),
+        sr: sampleRate
+      });
+    }
+
     async loadSamples() {
 
       let source = `https://cdn.jsdelivr.net/gh/chaosprint/glicol@v0.11.9/js/src/`


### PR DESCRIPTION
For applications that would like to add samples to glicol.js as `Float32Array`s, here is an `addSampleFromDataArray` method in the NPM module.