### PR TITLE
Fix parsing of multiline JS

### DIFF
--- a/js/src/glicol.js
+++ b/js/src/glicol.js
@@ -367,7 +367,7 @@ var {name, _} = detectBrowser();
 
 window.run = async (codeRaw) =>{
   
-  let regex = /(##.*?#)/
+  let regex = /(##.*?#)/s
   let parse = codeRaw.split(regex).filter(Boolean)
   let code = parse.map(str => {
       if (str.includes("#")) {


### PR DESCRIPTION
Parsing of multiline JS is broken because the regex used to split JS from Glicol code doesn't accept newlines. So this code doesn't work:

```
##
return "~o: seq 60 _ 60 _";
#

out: ~o >> sawsynth 0.01 0.1 >> mul 0.5 
```

, because the regex doesn't match, `parse` is therefore a 1-element array with all the code in it, and consequently it tries to include the `out: ~o >> ...` line in the JS function (if there's no Glicol code [like in the demo](https://glicol.org/tour#mixjs2), the hashes are removed and the code is syntactically valid despite the split not happening).

The solution was to add the `s` dotall flag to the parsing regex, which allows `.*?` to match the newlines.