### PR TITLE
Apply most clippy fixes

### DIFF
--- a/rs/main/src/error.rs
+++ b/rs/main/src/error.rs
@@ -24,7 +24,7 @@ pub fn get_error_info(e: Error<Rule>) -> (Vec<Rule>, Vec<Rule>) {
         ErrorVariant::ParsingError {
             positives,
             negatives,
-        } => return (positives, negatives),
+        } => (positives, negatives),
         _ => {
             unimplemented!();
         }


### PR DESCRIPTION
This applies most fixes which `clippy` recommends for this repository The only one which it doesn't apply is making `EngineError` `Box` its inner `pest::error::Error` (since that variant takes up 264 bytes, and boxing it could save a massive amount of space in the return type of many public functions) since that would change the public API of this crate. I didn't want to change the public API without raising that as a concern first.

This also goes a bit further than the simply fixes `clippy` suggests in two areas:
1. Avoids an allocation by by changing a call to `Vec::len` to instead call `next()` multiple times on the iterator that previously created the vector
2. Makes a complex branch statement with a lot of repeated code simpler and clearer

As far as I can tell, this doesn't change any behavior at all, but I plan to test that with `glicol-cli` later today to make sure it seems to still function fine. I would also like a second pair of eyes to look over these changes and make sure I didn't miss anything :)