### PR TITLE
Allow comments within chains in grammar

### DIFF
--- a/rs/parser/src/glicol.pest
+++ b/rs/parser/src/glicol.pest
@@ -1,7 +1,7 @@
 block = ${ SOI ~ ("\n"|WHITESPACE)* ~ ( (line|comment) ~ WHITESPACE* ~ ";"? ~ WHITESPACE* ~ ("\n" ~ WHITESPACE*)* )* ~ EOI}
 comment = _{ "//" ~ (!NEWLINE ~ ANY)* ~ NEWLINE* ~ !NEWLINE}
 line = ${ reference ~ WHITESPACE* ~ ":" ~ WHITESPACE* ~ chain}
-chain = ${ node ~ (WHITESPACE* ~ "\n"? ~ WHITESPACE* ~ ">>" ~ WHITESPACE* ~ node)*  }
+chain = ${ node ~ (WHITESPACE* ~ "\n"? ~ WHITESPACE* ~ ((">>" ~ WHITESPACE* ~ node) | comment) )*  }
 
 node = ${ (reverb|arrange|psampler|mix|seq|choose|mul|add|sin|saw|squ|tri|pan|speed|noise|onepole|
 sp|constsig|lpf|rhpf|onepole|imp|delayn|delayms|envperc|apfmsgain|plate|sendpass|

--- a/rs/parser/tests/sin.rs
+++ b/rs/parser/tests/sin.rs
@@ -5,3 +5,20 @@ fn minimal() {
     let res = get_ast("o: sin 440");
     assert!(res.is_ok());
 }
+
+#[test]
+fn comment_within_chain() {
+    let res = get_ast(
+        "o: sin 440
+    // >> mul 0.5
+    >> mul 0.6"
+    );
+    assert!(res.is_ok());
+
+    let res = get_ast(
+        "o: sin 440
+// ooooh this is nonsense
+>> add 6.00"
+    );
+    assert!(res.is_ok());
+}


### PR DESCRIPTION
While working with glicol, I found that it was very useful to structure my chains with one node per line, where I could (theoretically) comment out each line to try things out. However, this is not allowed with the current grammar, as comments can't exist in the middle of chains.

To accommodate for this, I changed the grammar to allow comments in the middle of chains, and added a test to verify that this works. I think that this makes sense as a part of the grammar, but am obviously open to suggestions.